### PR TITLE
Add missing types Int, Float and Double

### DIFF
--- a/src/Serializable.swift
+++ b/src/Serializable.swift
@@ -34,6 +34,12 @@ public class Serializable : NSObject{
                     subArray.append(item.toDictionary())
                 }
                 propertiesDictionary.setValue(subArray, forKey: propName)
+            } else if propValue is Double {
+                propertiesDictionary.setValue((propValue as Double), forKey: propName)
+            } else if propValue is Int {
+                propertiesDictionary.setValue((propValue as Int), forKey: propName)
+            } else if propValue is Float {
+                propertiesDictionary.setValue((propValue as Float), forKey: propName)
             } else if propValue is NSData {
                 propertiesDictionary.setValue((propValue as NSData).base64EncodedStringWithOptions(nil), forKey: propName)
             } else if propValue is Bool {


### PR DESCRIPTION
I've just modified the following code in order to support the type Int, Float and Double.
```swift
    public func toDictionary() -> NSDictionary {
        var aClass : AnyClass? = self.dynamicType
        var propertiesCount : CUnsignedInt = 0
        let propertiesInAClass : UnsafeMutablePointer<objc_property_t> = class_copyPropertyList(aClass, &propertiesCount)
        var propertiesDictionary : NSMutableDictionary = NSMutableDictionary()
   
        for var i = 0; i < Int(propertiesCount); i++ {
            var property = propertiesInAClass[i]
            var propName = NSString(CString: property_getName(property), encoding: NSUTF8StringEncoding)!
            var propType = property_getAttributes(property)
            var propValue : AnyObject! = self.valueForKey(propName);
            
            if propValue is Serializable {
                propertiesDictionary.setValue((propValue as Serializable).toDictionary(), forKey: propName)
            } else if propValue is Array<Serializable> {
                var subArray = Array<NSDictionary>()
                for item in (propValue as Array<Serializable>) {
                    subArray.append(item.toDictionary())
                }
                propertiesDictionary.setValue(subArray, forKey: propName)
            } else if propValue is Double {
                propertiesDictionary.setValue((propValue as Double), forKey: propName)
            } else if propValue is Int {
                propertiesDictionary.setValue((propValue as Int), forKey: propName)
            } else if propValue is Float {
                propertiesDictionary.setValue((propValue as Float), forKey: propName)
            } else if propValue is NSData {
                propertiesDictionary.setValue((propValue as NSData).base64EncodedStringWithOptions(nil), forKey: propName)
            } else if propValue is Bool {
                propertiesDictionary.setValue((propValue as Bool).boolValue, forKey: propName)
            } else {
                propertiesDictionary.setValue(propValue, forKey: propName)
            }
        }
        
        // class_copyPropertyList retaints all the 
        propertiesInAClass.dealloc(Int(propertiesCount))
        
        return propertiesDictionary
    }
```