### PR TITLE
Optionals support. Style and Swift 1.2 updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,24 +21,26 @@ class Person:Serializable {
 class Animal:Serializable {
     var Nickname : String
     var Kind : String
-    
-    init(Nickname : String, Kind : String) {
+    var Trick : String?
+
+    init(Nickname : String, Kind : String, Trick : String?) {
         self.Nickname = Nickname
         self.Kind = Kind
+        self.Trick = Trick
     }
 }
 
 class SerializationTests: XCTestCase {
     func test_serialization_works() {
         var john = Person(Name: "John", Surname: "Doe")
-    
-        john.Animals.append(Animal(Nickname: "Fluffy", Kind: "Dog"))
-        john.Animals.append(Animal(Nickname: "Purry", Kind: "Cat"))
+        
+        john.Animals.append(Animal(Nickname: "Fluffy", Kind: "Dog", Trick: "Rollover"))
+        john.Animals.append(Animal(Nickname: "Purry", Kind: "Cat", Trick: nil))
         
         println(john.toJson()) //will give binary data to include in HTTP Body
         println(john.toJsonString()) //will give the exact string in JSON
-
-        var expected = "{\"Surname\":\"Doe\",\"Name\":\"John\",\"Animals\":[{\"Kind\":\"Dog\",\"Nickname\":\"Fluffy\"},{\"Kind\":\"Cat\",\"Nickname\":\"Purry\"}]}";
+        
+        var expected = "{\"Surname\":\"Doe\",\"Name\":\"John\",\"Animals\":[{\"Trick\":\"Rollover\",\"Kind\":\"Dog\",\"Nickname\":\"Fluffy\"},{\"Kind\":\"Cat\",\"Nickname\":\"Purry\"}]}";
         
         XCTAssertEqual(john.toJsonString(), expected,"")
     }

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ import XCTest
 class Person:Serializable {
     var Name : String
     var Surname : String
+    var BirthTimestamp : NSNumber
     var Animals : Array<Animal>
-    
-    init(Name:String, Surname:String) {
+
+
+    init(Name:String, Surname:String, BirthTimestamp:NSNumber) {
         self.Name = Name
         self.Surname = Surname
+        self.BirthTimestamp = BirthTimestamp
         self.Animals = Array<Animal>()
     }
 }
@@ -32,7 +35,7 @@ class Animal:Serializable {
 
 class SerializationTests: XCTestCase {
     func test_serialization_works() {
-        var john = Person(Name: "John", Surname: "Doe")
+        var john = Person(Name: "John", Surname: "Doe", BirthTimestamp: 512463600000)
         
         john.Animals.append(Animal(Nickname: "Fluffy", Kind: "Dog", Trick: "Rollover"))
         john.Animals.append(Animal(Nickname: "Purry", Kind: "Cat", Trick: nil))
@@ -40,7 +43,7 @@ class SerializationTests: XCTestCase {
         println(john.toJson()) //will give binary data to include in HTTP Body
         println(john.toJsonString()) //will give the exact string in JSON
         
-        var expected = "{\"Surname\":\"Doe\",\"Name\":\"John\",\"Animals\":[{\"Trick\":\"Rollover\",\"Kind\":\"Dog\",\"Nickname\":\"Fluffy\"},{\"Kind\":\"Cat\",\"Nickname\":\"Purry\"}]}";
+        var expected = "{\"BirthTimestamp\":512463600000,\"Name\":\"John\",\"Animals\":[{\"Trick\":\"Rollover\",\"Kind\":\"Dog\",\"Nickname\":\"Fluffy\"},{\"Kind\":\"Cat\",\"Nickname\":\"Purry\"}],\"Surname\":\"Doe\"}";
         
         XCTAssertEqual(john.toJsonString(), expected,"")
     }


### PR DESCRIPTION
-Changed from Objective-C runtime reflection to Swift MirrorType reflection to enable optionals.
-Fixed Swift 1.2 errors.
-Altered the conditionals to use optional chaining to reduce repetitive typecasting.
-Updated test in readme to leverage new optional capabilities.

Addresses #3 and #6 