### PR TITLE
Swift 2.0 implementation

### DIFF
--- a/src/Serializable.swift
+++ b/src/Serializable.swift
@@ -23,10 +23,9 @@ public class Serializable: NSObject {
         let propertiesDictionary = NSMutableDictionary()
         let mirror = Mirror(reflecting: self)
 
-        for childMirror in mirror.children {
-            let propName = childMirror.label!
+        for (propName, propValue) in mirror.children {
 
-            if let propValue: AnyObject = self.unwrap(childMirror.value) as? AnyObject {
+            if let propValue: AnyObject = propValue as? AnyObject, propName = propName {
                 if let serializablePropValue = propValue as? Serializable {
                     propertiesDictionary.setValue(serializablePropValue.toDictionary(), forKey: propName)
                 } else if let arrayPropValue = propValue as? [Serializable] {
@@ -83,25 +82,5 @@ public class Serializable: NSObject {
         }
 
         return nil
-    }
-}
-
-extension Serializable {
-
-    /**
-    Unwraps 'any' object. See http://stackoverflow.com/questions/27989094/how-to-unwrap-an-optional-value-from-any-type
-
-    - returns: The unwrapped object.
-    */
-    private func unwrap(any: Any) -> Any? {
-        let mi = Mirror(reflecting: any)
-
-        if mi.children.count == 0 {
-            return nil
-        }
-
-        let (_, some) = mi.children.first!
-
-        return some
     }
 }

--- a/src/Serializable.swift
+++ b/src/Serializable.swift
@@ -90,7 +90,7 @@ extension Serializable {
     /**
     Unwraps 'any' object. See http://stackoverflow.com/questions/27989094/how-to-unwrap-an-optional-value-from-any-type
 
-    :returns: The unwrapped object.
+    - returns: The unwrapped object.
     */
     private func unwrap(any: Any) -> Any? {
         let mi = Mirror(reflecting: any)

--- a/src/Serializable.swift
+++ b/src/Serializable.swift
@@ -1,31 +1,31 @@
 /*
 
-    Converts A class to a dictionary, used for serializing dictionaries to JSON
+Converts A class to a dictionary, used for serializing dictionaries to JSON
 
-    Supported objects:
-    - Serializable derived classes (sub classes)
-    - Arrays of Serializable
-    - NSData
-    - String, Numeric, and all other NSJSONSerialization supported objects
+Supported objects:
+- Serializable derived classes (sub classes)
+- Arrays of Serializable
+- NSData
+- String, Numeric, and all other NSJSONSerialization supported objects
 
 */
 
 import Foundation
 
 public class Serializable: NSObject {
-    
+
     /**
-        Converts the class to a dictionary.
-    
-        :returns: The class as an NSDictionary.
+    Converts the class to a dictionary.
+
+    - returns: The class as an NSDictionary.
     */
     public func toDictionary() -> NSDictionary {
         let propertiesDictionary = NSMutableDictionary()
-        let mirror = reflect(self)
-        
-        for i in 1..<mirror.count {
-            let (propName, childMirror) = mirror[i]
-            
+        let mirror = Mirror(reflecting: self)
+
+        for childMirror in mirror.children {
+            let propName = childMirror.label!
+
             if let propValue: AnyObject = self.unwrap(childMirror.value) as? AnyObject {
                 if let serializablePropValue = propValue as? Serializable {
                     propertiesDictionary.setValue(serializablePropValue.toDictionary(), forKey: propName)
@@ -34,7 +34,7 @@ public class Serializable: NSObject {
                     for item in arrayPropValue {
                         subArray.append(item.toDictionary())
                     }
-                    
+
                     propertiesDictionary.setValue(subArray, forKey: propName)
                 } else if propValue is Int || propValue is Double || propValue is Float {
                     propertiesDictionary.setValue(propValue, forKey: propName)
@@ -47,66 +47,61 @@ public class Serializable: NSObject {
                 }
             }
         }
-        
+
         return propertiesDictionary
     }
-    
+
     /**
-        Converts the class to JSON.
-    
-        :returns: The class as JSON, wrapped in NSData.
+    Converts the class to JSON.
+
+    - returns: The class as JSON, wrapped in NSData.
     */
     public func toJson(prettyPrinted : Bool = false) -> NSData? {
         let dictionary = self.toDictionary()
-        
+
         if NSJSONSerialization.isValidJSONObject(dictionary) {
             do {
                 let json = try NSJSONSerialization.dataWithJSONObject(dictionary, options: (prettyPrinted ? .PrettyPrinted : NSJSONWritingOptions()))
                 return json
-            } catch {
-                //currently swift will not catch NSInvalidArgumentException exception
-                print("ERROR: Unable to serialize json, error: \(error)")
+            } catch let error as NSError {
+                print("ERROR: Unable to serialize json, error: \(error)", appendNewline: true)
                 NSNotificationCenter.defaultCenter().postNotificationName("CrashlyticsLogNotification", object: self, userInfo: ["string": "unable to serialize json, error: \(error)"])
             }
         }
-        
+
         return nil
     }
-    
+
     /**
-        Converts the class to a JSON string.
-    
-        :returns: The class as a JSON string.
+    Converts the class to a JSON string.
+
+    - returns: The class as a JSON string.
     */
     public func toJsonString(prettyPrinted : Bool = false) -> String? {
         if let jsonData = self.toJson(prettyPrinted) {
             return NSString(data: jsonData, encoding: NSUTF8StringEncoding) as String?
         }
-        
+
         return nil
     }
 }
 
 extension Serializable {
-    
+
     /**
-        Unwraps 'any' object. See http://stackoverflow.com/questions/27989094/how-to-unwrap-an-optional-value-from-any-type
-    
-        :returns: The unwrapped object.
+    Unwraps 'any' object. See http://stackoverflow.com/questions/27989094/how-to-unwrap-an-optional-value-from-any-type
+
+    - returns: The unwrapped object.
     */
     private func unwrap(any: Any) -> Any? {
-        let mi = reflect(any)
-        
-        if mi.disposition != .Optional {
-            return any
-        }
-        
-        if mi.count == 0 {
+        let mi = Mirror(reflecting: any)
+
+        if mi.children.count == 0 {
             return nil
         }
-        
-        let (_, some) = mi[0]
-        
-        return some.value
+
+        let (_, some) = mi.children.first!
+
+        return some
     }
 }

--- a/src/Serializable.swift
+++ b/src/Serializable.swift
@@ -24,8 +24,7 @@ public class Serializable: NSObject {
         let mirror = Mirror(reflecting: self)
 
         for (propName, propValue) in mirror.children {
-
-            if let propValue: AnyObject = propValue as? AnyObject, propName = propName {
+            if let propValue: AnyObject = self.unwrap(propValue) as? AnyObject, propName = propName {
                 if let serializablePropValue = propValue as? Serializable {
                     propertiesDictionary.setValue(serializablePropValue.toDictionary(), forKey: propName)
                 } else if let arrayPropValue = propValue as? [Serializable] {
@@ -82,5 +81,30 @@ public class Serializable: NSObject {
         }
 
         return nil
+    }
+
+}
+
+extension Serializable {
+
+    /**
+    Unwraps 'any' object. See http://stackoverflow.com/questions/27989094/how-to-unwrap-an-optional-value-from-any-type
+
+    :returns: The unwrapped object.
+    */
+    private func unwrap(any: Any) -> Any? {
+        let mi = Mirror(reflecting: any)
+
+        if mi.displayStyle != .Optional {
+            return any
+        }
+
+        if mi.children.count == 0 {
+            return nil
+        }
+
+        let (_, some) = mi.children.first!
+
+        return some
     }
 }

--- a/tests/SerializableSpec.swift
+++ b/tests/SerializableSpec.swift
@@ -69,7 +69,7 @@ class SerializableSpec: QuickSpec {
             }
             
             it("should be serialized") {
-                let expected = "{\"BirthTimestamp\":51246360,\"Surname\":\"Doe\",\"Animals\":[],\"Name\":\"John\"}";
+                let expected = "{\"BirthTimestamp\":51246360,\"Name\":\"John\",\"Animals\":[],\"Surname\":\"Doe\"}";
                 expect(john.toJsonString()).to(equal(expected))
             }
         }
@@ -84,7 +84,7 @@ class SerializableSpec: QuickSpec {
             }
             
             it("should be serialized") {
-                let expected = "{\"BirthTimestamp\":51246360,\"Surname\":\"Doe\",\"Animals\":[{\"Trick\":\"Rollover\",\"Nickname\":\"Fluffy\",\"Kind\":\"Dog\"},{\"Nickname\":\"Purry\",\"Kind\":\"Cat\"}],\"Name\":\"John\"}";
+                let expected = "{\"BirthTimestamp\":51246360,\"Name\":\"John\",\"Animals\":[{\"Trick\":\"Rollover\",\"Kind\":\"Dog\",\"Nickname\":\"Fluffy\"},{\"Kind\":\"Cat\",\"Nickname\":\"Purry\"}],\"Surname\":\"Doe\"}";
                 expect(john.toJsonString()).to(equal(expected))
             }
         }


### PR DESCRIPTION
- Ran Swift 2.0 conversion
- Updated the reflect() method to use the Mirror(reflecting:) initializer
- ~~unwrap method no longer seems to be necessary~~

**DO NOT MERGE! I can put up another PR if a 'swift-2.0' branch is created since this is for swift 2.0**

## Notes
- I am using this implementation in a client project and in my initial testing it seems to be working just fine. I don't really know a whole lot about Mirror and reflect and welcome any feedback people might have.
- ~~One of the test cases is failing but I'm not positive it is a real error. Information below~~

~~**actual**~~
~~p john.toJsonString()~~
~~(String?) $R0 = "{\"BirthTimestamp\":51246360,\"Name\":\"John\",\"Animals\":[],\"Surname\":\"Doe\"}"~~
~~**expected**~~
~~let expected = "{\"BirthTimestamp\":51246360,\"Surname\":\"Doe\",\"Animals\":[],\"Name\":\"John\"}";~~

~~Is it a real issue if the order isn't the same?~~

**Update: 07/30/15:**
I have updated the tests to match what is being returned for me since the object structure itself is the same

