### PR TITLE
Fix podspec error:

### DIFF
--- a/SwiftSerializer.podspec
+++ b/SwiftSerializer.podspec
@@ -7,9 +7,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/Mailcloud/swift-serializer.git", :tag => "#{s.version}" }
   s.authors      = {'Mailcloud' => "contact@mailcloud.com"}
   s.social_media_url   = "https://twitter.com/mailcloud"
-  s.ios.platform  = :ios, '8.0'
   s.ios.deployment_target = "8.0"
-  s.osx.platform  = :osx, '10.9'
   s.osx.deployment_target = "10.9"
   s.source_files  = "src/*"
   s.requires_arc = true


### PR DESCRIPTION
[!] Unable to load a podspec from `SwiftSerializer.podspec`, skipping:
Pod::DSLError